### PR TITLE
add prefix to obfuscate repository name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,9 +30,9 @@ inputs:
     description: "URL for credential provider"
     required: false
   obfuscate-repository:
-    description: "obfuscate your repository name by SHA-256"
+    description: "obfuscate your repository name"
     required: true
-    default: false
+    default: ""
 runs:
   using: "node12"
   main: "action/lib/index.js"

--- a/action/__test__/index.test.ts
+++ b/action/__test__/index.test.ts
@@ -58,7 +58,7 @@ describe('tests', () => {
       roleSessionName: 'GitHubActions',
       roleSessionTagging: true,
       providerEndpoint: 'http://localhost:8080',
-      obfuscateRepository: false
+      obfuscateRepository: ''
     });
     expect(process.env.AWS_ACCESS_KEY_ID).toBe('AKIAIOSFODNN7EXAMPLE');
     expect(process.env.AWS_SECRET_ACCESS_KEY).toBe('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
@@ -77,7 +77,7 @@ describe('tests', () => {
         roleSessionName: 'GitHubActions',
         roleSessionTagging: true,
         providerEndpoint: 'http://localhost:8080',
-        obfuscateRepository: false
+        obfuscateRepository: ''
       });
     }).rejects.toThrow();
   });

--- a/action/src/index.ts
+++ b/action/src/index.ts
@@ -9,7 +9,7 @@ interface AssumeRoleParams {
   roleSessionName: string;
   roleSessionTagging: boolean;
   providerEndpoint: string;
-  obfuscateRepository: boolean;
+  obfuscateRepository: string;
 }
 
 interface AssumeRolePayload {
@@ -19,7 +19,7 @@ interface AssumeRolePayload {
   duration_seconds: number;
   api_url: string;
   repository: string;
-  obfuscate_repository: boolean;
+  obfuscate_repository: string;
   sha: string;
   role_session_tagging: boolean;
   run_id: string;
@@ -152,7 +152,7 @@ async function run() {
     const roleSessionTagging = core.getBooleanInput('role-session-tagging', required);
     const providerEndpoint =
       core.getInput('provider-endpoint') || 'https://uw4qs7ndjj.execute-api.us-east-1.amazonaws.com/assume-role';
-    const obfuscateRepository = core.getBooleanInput('obfuscate-repository', required);
+    const obfuscateRepository = core.getInput('obfuscate-repository', required);
     await assumeRole({
       githubToken,
       awsRegion,

--- a/provider/assume-role/assume-role.go
+++ b/provider/assume-role/assume-role.go
@@ -312,7 +312,7 @@ func (h *Handler) assumeRole(ctx context.Context, req *requestBody) (*responseBo
 	input := *validationInput
 	if req.ObfuscateRepository {
 		hash := sha256.Sum256([]byte(req.Repository))
-		input.ExternalId = aws.String(hex.EncodeToString(hash[:]))
+		input.ExternalId = aws.String("sha256:" + hex.EncodeToString(hash[:]))
 	} else {
 		input.ExternalId = aws.String(req.Repository)
 	}

--- a/provider/assume-role/assume-role.go
+++ b/provider/assume-role/assume-role.go
@@ -77,7 +77,7 @@ type requestBody struct {
 	RoleSessionName     string `json:"role_session_name"`
 	DurationSeconds     int32  `json:"duration_seconds"`
 	Repository          string `json:"repository"`
-	ObfuscateRepository bool   `json:"obfuscate_repository"`
+	ObfuscateRepository string `json:"obfuscate_repository"`
 	APIURL              string `json:"api_url"`
 	SHA                 string `json:"sha"`
 	RoleSessionTagging  bool   `json:"role_session_tagging"`
@@ -310,11 +310,14 @@ func (h *Handler) assumeRole(ctx context.Context, req *requestBody) (*responseBo
 
 	// assume role with the correct external ID
 	input := *validationInput
-	if req.ObfuscateRepository {
+	switch req.ObfuscateRepository {
+	case "sha256":
 		hash := sha256.Sum256([]byte(req.Repository))
 		input.ExternalId = aws.String("sha256:" + hex.EncodeToString(hash[:]))
-	} else {
+	case "":
 		input.ExternalId = aws.String(req.Repository)
+	default:
+		return nil, fmt.Errorf("invalid obfuscate repository type: %s", req.ObfuscateRepository)
 	}
 	input.DurationSeconds = aws.Int32(req.DurationSeconds)
 	resp, err := h.sts.AssumeRole(ctx, &input)

--- a/provider/assume-role/assume-role_test.go
+++ b/provider/assume-role/assume-role_test.go
@@ -205,7 +205,7 @@ func TestAssumeRole_ObfuscateRepository(t *testing.T) {
 				if params.ExternalId == nil {
 					return nil, errAccessDenied
 				}
-				if got, want := aws.ToString(params.ExternalId), "339c2238399e1150eb8d76a7a74cfd92448d347dc4212bad33a4978edfc455e0"; want != got {
+				if got, want := aws.ToString(params.ExternalId), "sha256:339c2238399e1150eb8d76a7a74cfd92448d347dc4212bad33a4978edfc455e0"; want != got {
 					t.Errorf("unexpected external id: want %q, got %q", want, got)
 					return nil, errAccessDenied
 				}

--- a/provider/assume-role/assume-role_test.go
+++ b/provider/assume-role/assume-role_test.go
@@ -223,7 +223,7 @@ func TestAssumeRole_ObfuscateRepository(t *testing.T) {
 		RoleToAssume:        "arn:aws:iam::123456789012:role/assume-role-test",
 		RoleSessionName:     "GitHubActions",
 		Repository:          "fuller-inc/actions-aws-assume-role",
-		ObfuscateRepository: true,
+		ObfuscateRepository: "sha256",
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Currently, many people think SHA-256 is safe, however it's vulnerability might be found in future.
so we allow users to change hashing algorithm.