### PR TITLE
ignore public keys that have unknown kyt

### DIFF
--- a/provider/assume-role/github/jwk/jwks.go
+++ b/provider/assume-role/github/jwk/jwks.go
@@ -16,11 +16,10 @@ func ParseSet(data []byte) (*Set, error) {
 
 	list := make([]Key, 0, len(keys.Keys))
 	for _, raw := range keys.Keys {
-		key, err := ParseKey(raw)
-		if err != nil {
-			return nil, err
+		if key, err := ParseKey(raw); err == nil {
+			list = append(list, key)
+			// Ignore keys that cannot be parsed.
 		}
-		list = append(list, key)
 	}
 	return &Set{
 		Keys: list,

--- a/provider/assume-role/github/oidc/jwks.go
+++ b/provider/assume-role/github/oidc/jwks.go
@@ -49,7 +49,7 @@ func (c *Client) GetJWKS(ctx context.Context, url string) (*jwk.Set, error) {
 
 		set, err := jwk.ParseSet(data)
 		if err != nil {
-
+			return nil, time.Time{}, err
 		}
 		return set, expiresAt, nil
 	})


### PR DESCRIPTION
A new key type may be added into the `kty` parameter in the future.
So, we should ignore unknown keys that have unknown `kty`.