### PR TITLE
introduce Grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,5 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
@@ -14,12 +12,24 @@ updates:
       # update too often, ignore patch releases
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-patch"]
+    groups:
+      # jest
+      jest-monorepo:
+        patterns:
+          - "jest"
+          - "jest-*"
 
   # Maintain dependencies for Go
   - package-ecosystem: "gomod"
     directory: "/provider/assume-role"
     schedule:
       interval: "daily"
+    groups:
+      # AWS SDK
+      aws-sdk:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2"
+          - "github.com/aws/aws-sdk-go-v2/*"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Grouped version updates for Dependabot public beta https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/